### PR TITLE
fix boundary case for hotkey 'previous'

### DIFF
--- a/src/app/components/sideNav/sidenav.controller.js
+++ b/src/app/components/sideNav/sidenav.controller.js
@@ -59,7 +59,7 @@
       description: 'Previous of health recommendations',
       callback: function() {
         var i = states.indexOf($state.current.name);
-        var previousState = states[(i-1)%4];
+        var previousState = states[(i+3)%4];
         $state.go(previousState);
       }
     });


### PR DESCRIPTION
if i == 0, previousState refer to states[-1] un
